### PR TITLE
Decrease the batch size

### DIFF
--- a/messages/service.go
+++ b/messages/service.go
@@ -9,7 +9,7 @@ import (
 
 // We're using this batch size, because if we put too many subjects there,
 // we hit an AWS limit on the SNS message size
-const batchSize = 3000
+const batchSize = 1000
 
 // MessageService is an interface for sending messages to the derivative service
 type MessageService interface {


### PR DESCRIPTION
To avoid SNS errors like this:
```
ErrorMessage\":\"176294 byte payload is too large for the Event invocation type (limit 131072 bytes)
```