### PR TITLE
Update circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
             aws configure set region $AWS_REGION
             aws configure set default.output json
             aws configure list  # Get confirmation it worked in your logs
-            aws lambda update-function-code --function-name triggerRebuild --zip-file fileb://lambda.zip
+            aws lambda update-function-code --function-name rialto-trigger-rebuild-development --zip-file fileb://lambda.zip
 
 workflows:
   version: 2


### PR DESCRIPTION
This should fix the broken master build, which then pushes the lambda up to AWS on a successful merge to master.